### PR TITLE
Add skeleton for yarp device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@
 *.exe
 *.out
 *.app
+
+# Build system and IDEs
+build*/
+.project
+.cproject
+.settings/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Copyright (C) 2006-2022 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#W
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+cmake_minimum_required(VERSION 3.12)
+project(yarp-device-pylon
+        LANGUAGES CXX
+        VERSION 0.1.0)
+
+include(FeatureSummary)
+
+find_package(YCM 0.11 REQUIRED)
+find_package(YARP 3.5 COMPONENTS os sig dev OPTIONAL_COMPONENTS math REQUIRED)
+find_package(pylon 7.1.0 REQUIRED)
+
+include(GNUInstallDirs)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
+if(MSVC)
+  set(CMAKE_DEBUG_POSTFIX "d")
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(YARP_FORCE_DYNAMIC_PLUGINS TRUE CACHE INTERNAL "yarp-device-pylon is always built with dynamic plugins")
+set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build libraries as shared as opposed to static")
+
+include(AddInstallRPATHSupport)
+add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"
+                          LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"
+                          INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
+                          USE_LINK_PATH)
+
+if(NOT CMAKE_CONFIGURATION_TYPES)
+    if(NOT CMAKE_BUILD_TYPE)
+        message(STATUS "Setting build type to 'Release' as none was specified.")
+        set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+    endif()
+endif()
+
+set_property(GLOBAL PROPERTY USE_FOLDERS 1)
+
+include(AddUninstallTarget)
+
+
+set(CMAKE_C_FLAGS "${YARP_C_FLAGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${YARP_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+
+yarp_configure_plugins_installation(yarp-device-pylon)
+
+feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+add_subdirectory(devices)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (C) 2006-2022 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+add_subdirectory(pylon)

--- a/src/devices/pylon/CMakeLists.txt
+++ b/src/devices/pylon/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+yarp_prepare_plugin(pylon
+  CATEGORY device
+  TYPE pylonDriver
+  INCLUDE pylonDriver.h
+  EXTRA_CONFIG WRAPPER=frameGrabber_nws_yarp
+  DEPENDS "pylon_FOUND"
+  DEFAULT ON
+)
+
+if(ENABLE_pylon)
+  yarp_add_plugin(yarp_pylon)
+
+  target_sources(yarp_pylon
+    PRIVATE
+      pylonDriver.cpp
+      pylonDriver.h
+  )
+
+  target_link_libraries(yarp_pylon
+    PUBLIC
+      YARP::YARP_os
+      YARP::YARP_sig
+      YARP::YARP_dev
+      pylon::pylon
+  )
+
+  yarp_install(
+    TARGETS yarp_pylon
+    EXPORT yarp-device-pylon
+    COMPONENT yarp-device-pylon
+    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+    YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+  )
+
+  set_property(TARGET yarp_pylon PROPERTY FOLDER "Plugins/Device")
+endif()

--- a/src/devices/pylon/pylonDriver.cpp
+++ b/src/devices/pylon/pylonDriver.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2006-2022 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <cmath>
+#include <algorithm>
+#include <iomanip>
+#include <cstdint>
+
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/Value.h>
+#include <yarp/sig/ImageUtils.h>
+
+
+#include "pylonDriver.h"
+
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace yarp::os;
+
+using namespace std;
+
+namespace {
+YARP_LOG_COMPONENT(PYLON, "yarp.device.pylon")
+}
+
+pylonDriver::pylonDriver()
+{
+}
+
+
+bool pylonDriver::setFramerate(const int _fps)
+{
+    return true;
+}
+
+
+bool pylonDriver::open(Searchable& config)
+{
+    return true;
+}
+
+bool pylonDriver::close()
+{
+    return true;
+}
+
+int pylonDriver::getRgbHeight()
+{
+    return 0;
+}
+
+int pylonDriver::getRgbWidth()
+{
+    return 0;
+}
+
+bool pylonDriver::getRgbSupportedConfigurations(yarp::sig::VectorOf<CameraConfig> &configurations)
+{
+    yCWarning(PYLON) << "getRgbSupportedConfigurations not implemented yet";
+    return false;
+}
+
+bool pylonDriver::getRgbResolution(int &width, int &height)
+{
+    return true;
+}
+
+
+bool pylonDriver::setRgbResolution(int width, int height)
+{
+
+    return true;
+}
+
+
+bool pylonDriver::setRgbFOV(double horizontalFov, double verticalFov)
+{
+    // It seems to be not available...
+    return false;
+}
+
+bool pylonDriver::getRgbFOV(double &horizontalFov, double &verticalFov)
+{
+    return true;
+}
+
+bool pylonDriver::getRgbMirroring(bool& mirror)
+{
+    yCWarning(PYLON) << "Mirroring not supported";
+    return false;
+}
+
+bool pylonDriver::setRgbMirroring(bool mirror)
+{
+    yCWarning(PYLON) << "Mirroring not supported";
+    return false;
+}
+
+bool pylonDriver::getRgbIntrinsicParam(Property& intrinsic)
+{
+    return true;
+}
+
+
+bool pylonDriver::getCameraDescription(CameraDescriptor* camera)
+{
+    return true;
+}
+
+bool pylonDriver::hasFeature(int feature, bool* hasFeature)
+{
+    return true;
+}
+
+bool pylonDriver::setFeature(int feature, double value)
+{
+    return true;
+}
+
+bool pylonDriver::getFeature(int feature, double *value)
+{
+    return true;
+}
+
+bool pylonDriver::setFeature(int feature, double value1, double value2)
+{
+    yCError(PYLON) << "No 2-valued feature are supported";
+    return false;
+}
+
+bool pylonDriver::getFeature(int feature, double *value1, double *value2)
+{
+    yCError(PYLON) << "No 2-valued feature are supported";
+    return false;
+}
+
+bool pylonDriver::hasOnOff(  int feature, bool *HasOnOff)
+{
+    return true;
+}
+
+bool pylonDriver::setActive( int feature, bool onoff)
+{
+
+    return true;
+}
+
+bool pylonDriver::getActive( int feature, bool *isActive)
+{
+    return true;
+}
+
+bool pylonDriver::hasAuto(int feature, bool *hasAuto)
+{
+    return true;
+}
+
+bool pylonDriver::hasManual( int feature, bool* hasManual)
+{
+    return true;
+}
+
+bool pylonDriver::hasOnePush(int feature, bool* hasOnePush)
+{
+    return hasAuto(feature, hasOnePush);
+}
+
+bool pylonDriver::setMode(int feature, FeatureMode mode)
+{
+    yCError(PYLON) << "Feature does not have both auto and manual mode";
+    return false;
+}
+
+bool pylonDriver::getMode(int feature, FeatureMode* mode)
+{
+    return true;
+}
+
+bool pylonDriver::setOnePush(int feature)
+{
+    return true;
+}
+
+bool pylonDriver::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
+{
+    return true;
+}
+
+int  pylonDriver::height() const
+{
+    return 0;
+}
+
+int  pylonDriver::width() const
+{
+    return 0;
+}

--- a/src/devices/pylon/pylonDriver.h
+++ b/src/devices/pylon/pylonDriver.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2006-2022 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef PYLON_DRIVER_H
+#define PYLON_DRIVER_H
+
+#include <iostream>
+#include <cstring>
+#include <map>
+#include <mutex>
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IFrameGrabberControls.h>
+#include <yarp/dev/IFrameGrabberImage.h>
+#include <yarp/dev/IRgbVisualParams.h>
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/sig/all.h>
+#include <yarp/sig/Matrix.h>
+#include <yarp/os/Stamp.h>
+#include <pylon/PylonIncludes.h>
+
+
+class pylonDriver :
+        public yarp::dev::DeviceDriver,
+        public yarp::dev::IFrameGrabberControls,
+        public yarp::dev::IFrameGrabberImage,
+        public yarp::dev::IRgbVisualParams
+{
+private:
+    typedef yarp::sig::ImageOf<yarp::sig::PixelFloat> depthImage;
+    typedef yarp::os::Stamp                           Stamp;
+    typedef yarp::os::Property                        Property;
+    typedef yarp::sig::FlexImage                      FlexImage;
+
+
+public:
+    pylonDriver();
+    ~pylonDriver() override = default;
+
+    // DeviceDriver
+    bool open(yarp::os::Searchable& config) override;
+    bool close() override;
+
+    // IRgbVisualParams
+    int    getRgbHeight() override;
+    int    getRgbWidth() override;
+    bool   getRgbSupportedConfigurations(yarp::sig::VectorOf<yarp::dev::CameraConfig> &configurations) override;
+    bool   getRgbResolution(int &width, int &height) override;
+    bool   setRgbResolution(int width, int height) override;
+    bool   getRgbFOV(double& horizontalFov, double& verticalFov) override;
+    bool   setRgbFOV(double horizontalFov, double verticalFov) override;
+    bool   getRgbMirroring(bool& mirror) override;
+    bool   setRgbMirroring(bool mirror) override;
+    bool   getRgbIntrinsicParam(Property& intrinsic) override;
+
+
+    //IFrameGrabberControls
+    bool   getCameraDescription(CameraDescriptor *camera) override;
+    bool   hasFeature(int feature, bool*   hasFeature) override;
+    bool   setFeature(int feature, double  value) override;
+    bool   getFeature(int feature, double* value) override;
+    bool   setFeature(int feature, double  value1,  double  value2) override;
+    bool   getFeature(int feature, double* value1,  double* value2) override;
+    bool   hasOnOff(  int feature, bool*   HasOnOff) override;
+    bool   setActive( int feature, bool    onoff) override;
+    bool   getActive( int feature, bool*   isActive) override;
+    bool   hasAuto(   int feature, bool*   hasAuto) override;
+    bool   hasManual( int feature, bool*   hasManual) override;
+    bool   hasOnePush(int feature, bool*   hasOnePush) override;
+    bool   setMode(   int feature, FeatureMode mode) override;
+    bool   getMode(   int feature, FeatureMode *mode) override;
+    bool   setOnePush(int feature) override;
+
+    //IFrameGrabberImage
+    bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) override;
+    int height() const override;
+    int width() const override;
+
+private:
+    //method
+    //inline bool setParams();
+    bool        setFramerate(const int _fps);
+
+
+    mutable std::mutex m_mutex;
+
+    yarp::os::Stamp m_rgb_stamp;
+    mutable std::string m_lastError;
+    bool m_verbose;
+    bool m_initialized;
+    int m_fps;
+};
+#endif // PYLON_DRIVER_H


### PR DESCRIPTION
I decided to call it `pylon` because it is a device that uses the pylon SDK for retrieving images, like https://github.com/basler/pylon-ros-camera.

In this sense I would change the name of the repo to `yarp-device-pylon`

cc @pattacini @triccyx 