### PR TITLE
pylonCamera: fix artifacts when rotating

### DIFF
--- a/src/devices/pylonCamera/pylonCameraDriver.cpp
+++ b/src/devices/pylonCamera/pylonCameraDriver.cpp
@@ -707,7 +707,7 @@ bool pylonCameraDriver::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
 #else
                 cv::rotate(rotated, rotated, rotationToCVRot.at(m_rotation));
 #endif  // USE_CUDA
-                image = yarp::cv::fromCvMat<yarp::sig::PixelRgb>(rotated);
+                image.copy(yarp::cv::fromCvMat<yarp::sig::PixelRgb>(rotated));
             }
             else
             {


### PR DESCRIPTION
This PR introduce a copy when rotating for fixing artifacts for buffering problems
They were due to the fact that both `cv::Mat` and `fromCvMat` does not deep copy, they just copy pointers to the data.

BEFORE
![immagine](https://user-images.githubusercontent.com/19152494/188833802-f24cccfe-c974-4d1c-b08e-aeea08e87dc9.png)



AFTER

![immagine](https://user-images.githubusercontent.com/19152494/188847378-0e1d9499-1c6e-49e6-a765-34138b0b3d33.png)
